### PR TITLE
chore: PrivacyInfo.xcprivacyを追加

### DIFF
--- a/WillMeter/Resources/PrivacyInfo.xcprivacy
+++ b/WillMeter/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## 概要
UserDefaults（Appleの必須理由API: Required Reason API）を使用しているにもかかわらず、プライバシーマニフェスト（`PrivacyInfo.xcprivacy`）が存在しなかった。未申告のままではApp Store/TestFlight審査で拒否されるリスクがある。

## 変更内容
- `WillMeter/Resources/PrivacyInfo.xcprivacy` を追加
- 使用しているAPIカテゴリ `NSPrivacyAccessedAPICategoryUserDefaults` を、理由コード `CA92.1`（アプリ自身のみがアクセスする情報の読み書き）で申告
- トラッキング・データ収集は行っていないため、`NSPrivacyTracking` は `false`、`NSPrivacyCollectedDataTypes` は空配列とした

## 動作確認
- `plutil -lint` でplist構文を検証
- `xcodebuild build` が成功し、ビルド成果物（`WillMeter.app`）に `PrivacyInfo.xcprivacy` が正しく含まれることを確認
- このプロジェクトはXcode 16のFile System Synchronized Groupsを使用しているため、`WillMeter/Resources/` にファイルを配置するだけでproject.pbxprojの追加編集は不要だった

## Closes
Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)