### PR TITLE
ci: PR/pushごとのCIにSwiftLintを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Run SwiftLint
+        run: swiftlint --quiet
+
       - name: Select Xcode version
         run: |
           # 最新の安定版Xcodeを選ぶ(ベータ版は除外)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install SwiftLint
+        run: |
+          if ! command -v swiftlint >/dev/null 2>&1; then
+            brew install swiftlint
+          fi
+
       - name: Run SwiftLint
         run: swiftlint --quiet
 


### PR DESCRIPTION
## 概要
`.swiftlint.yml` は整備されていたが、push/PR時に動く `ci.yml` はユニットテストのみ実行しておりSwiftLintを実行していなかった。Lint違反があってもCIをすり抜けてしまう状態だった。

## 変更内容
- `ci.yml` のチェックアウト直後に `swiftlint --quiet` を実行するステップを追加（pre-commit hookと同じコマンドで、ローカルとCIのLint基準を一致させた）

## 動作確認
- ローカルで `swiftlint --quiet` が exit code 0 で完了することを確認
- `xcodebuild build` が成功することを確認

## Closes
Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI環境にSwiftLintのチェックを追加しました。
  * SwiftLintが未導入の場合は自動インストールし、コード品質チェックを実行します。
  * 既存のビルドおよびユニットテスト処理は維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->