### PR TITLE
feat: アクセシビリティラベルの未対応箇所を補完

### DIFF
--- a/WillMeter/ContentView.swift
+++ b/WillMeter/ContentView.swift
@@ -107,6 +107,12 @@ struct ContentView: View {
                     } label: {
                         Image(systemName: "globe")
                     }
+                    .accessibilityLabel(
+                        localizationService.localizedString(for: LocalizationKeys.UI.Accessibility.languageButton)
+                    )
+                    .accessibilityHint(
+                        localizationService.localizedString(for: LocalizationKeys.UI.Accessibility.languageButtonHint)
+                    )
                 }
             }
             .sheet(isPresented: $showLanguageSettings) {
@@ -156,6 +162,9 @@ struct WillPowerDisplayView: View {
                 }
             }
             .frame(width: 200, height: 200)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(localizationService.localizedString(for: LocalizationKeys.WillPower.title))
+            .accessibilityValue("\(viewModel.displayText), \(viewModel.statusText)")
 
             // Status Information
             VStack(spacing: 10) {

--- a/WillMeter/Domain/Services/LocalizationService.swift
+++ b/WillMeter/Domain/Services/LocalizationService.swift
@@ -75,6 +75,8 @@ public enum LocalizationKeys {
             public static let consumeHint = "ui.accessibility.consume.hint"
             public static let restoreHint = "ui.accessibility.restore.hint"
             public static let resetHint = "ui.accessibility.reset.hint"
+            public static let languageButton = "ui.accessibility.language.button"
+            public static let languageButtonHint = "ui.accessibility.language.button.hint"
         }
     }
 

--- a/WillMeter/Presentation/Views/LanguageSettingsView.swift
+++ b/WillMeter/Presentation/Views/LanguageSettingsView.swift
@@ -104,6 +104,9 @@ private struct LanguageSelectionRow: View {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(displayName), \(languageCode.uppercased())")
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 }
 

--- a/WillMeter/Resources/en.lproj/Localizable.strings
+++ b/WillMeter/Resources/en.lproj/Localizable.strings
@@ -36,6 +36,8 @@
 "ui.accessibility.consume.hint" = "Reduces current willpower by %d points";
 "ui.accessibility.restore.hint" = "Adds %d points to current willpower";
 "ui.accessibility.reset.hint" = "Resets willpower to maximum value";
+"ui.accessibility.language.button" = "Language settings";
+"ui.accessibility.language.button.hint" = "Opens the language selection screen";
 
 // MARK: - Recommendations
 "recommendation.excellent" = "Excellent condition! Perfect time for high-concentration tasks.";

--- a/WillMeter/Resources/ja.lproj/Localizable.strings
+++ b/WillMeter/Resources/ja.lproj/Localizable.strings
@@ -36,6 +36,8 @@
 "ui.accessibility.consume.hint" = "現在の意志力から%dポイントを減らします";
 "ui.accessibility.restore.hint" = "現在の意志力に%dポイントを追加します";
 "ui.accessibility.reset.hint" = "意志力を最大値に戻します";
+"ui.accessibility.language.button" = "言語設定";
+"ui.accessibility.language.button.hint" = "言語選択画面を開きます";
 
 // MARK: - 推奨アクション
 "recommendation.excellent" = "素晴らしい状態です！集中力の高い作業に取り組みましょう。";

--- a/WillMeter/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WillMeter/Resources/zh-Hans.lproj/Localizable.strings
@@ -36,6 +36,8 @@
 "ui.accessibility.consume.hint" = "从当前意志力中减少%d点";
 "ui.accessibility.restore.hint" = "为当前意志力增加%d点";
 "ui.accessibility.reset.hint" = "将意志力重置为最大值";
+"ui.accessibility.language.button" = "语言设置";
+"ui.accessibility.language.button.hint" = "打开语言选择界面";
 
 // MARK: - 建议操作
 "recommendation.excellent" = "状态极佳！非常适合进行需要高度集中的任务。";

--- a/WillMeterTests/Domain/Services/LocalizationServiceTests.swift
+++ b/WillMeterTests/Domain/Services/LocalizationServiceTests.swift
@@ -80,7 +80,9 @@ final class LocalizationServiceTests: XCTestCase {
         let accessibilityKeys = [
             LocalizationKeys.UI.Accessibility.consumeHint,
             LocalizationKeys.UI.Accessibility.restoreHint,
-            LocalizationKeys.UI.Accessibility.resetHint
+            LocalizationKeys.UI.Accessibility.resetHint,
+            LocalizationKeys.UI.Accessibility.languageButton,
+            LocalizationKeys.UI.Accessibility.languageButtonHint
         ]
 
         // Then: 全アクセシビリティキーが定義されている
@@ -167,6 +169,8 @@ final class LocalizationServiceTests: XCTestCase {
             LocalizationKeys.UI.Accessibility.consumeHint,
             LocalizationKeys.UI.Accessibility.restoreHint,
             LocalizationKeys.UI.Accessibility.resetHint,
+            LocalizationKeys.UI.Accessibility.languageButton,
+            LocalizationKeys.UI.Accessibility.languageButtonHint,
 
             // Recommendation keys
             LocalizationKeys.Recommendation.excellent,


### PR DESCRIPTION
## 概要
メインの消費/回復/リセットボタンにはaccessibilityLabel/Hintが設定されていたが、以下の箇所が未対応だった:
- ツールバーの言語切替ボタン（globeアイコン）
- ウィルパワーゲージ全体（VoiceOverで現在値・最大値・状態がバラバラに読み上げられる）
- 言語選択行の選択状態（チェックマークがVoiceOverで伝わらない）

## 変更内容
- 言語切替ボタンに`accessibilityLabel`/`accessibilityHint`を追加（3言語分のローカライズ文字列を新設）
- ウィルパワーゲージを`accessibilityElement(children: .ignore)`で1つの要素にまとめ、現在値/最大値/状態を1回で読み上げるようにした
- 言語選択行に`accessibilityAddTraits(.isSelected)`を追加し、選択中の言語がVoiceOverで判別できるようにした
- 新規ローカライズキーを`LocalizationServiceTests`の必須キー一覧テストにも反映

## 動作確認
- `swiftlint --quiet` / `xcodebuild test` / `xcodebuild build` が成功

## Closes
Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)