### PR TITLE
feat: 初回起動時のオンボーディング画面を追加

### DIFF
--- a/WillMeter/ContentView.swift
+++ b/WillMeter/ContentView.swift
@@ -13,6 +13,8 @@ struct ContentView: View {
     @StateObject private var localizationService: SwiftUILocalizationService
     @StateObject private var willPowerViewModel: WillPowerViewModel
     @State private var showLanguageSettings = false
+    @AppStorage("hasCompletedOnboarding")
+    private var hasCompletedOnboarding = false
 
     private let willPowerStepAmount = 20
 
@@ -112,6 +114,21 @@ struct ContentView: View {
             .sheet(isPresented: $showLanguageSettings) {
                 LanguageSettingsView()
                     .environmentObject(localizationService)
+            }
+            .fullScreenCover(
+                isPresented: Binding(
+                    get: { !hasCompletedOnboarding },
+                    set: { isPresented in
+                        if !isPresented {
+                            hasCompletedOnboarding = true
+                        }
+                    }
+                )
+            ) {
+                OnboardingView {
+                    hasCompletedOnboarding = true
+                }
+                .environmentObject(localizationService)
             }
         }
         .task {

--- a/WillMeter/Domain/Services/LocalizationService.swift
+++ b/WillMeter/Domain/Services/LocalizationService.swift
@@ -83,6 +83,16 @@ public enum LocalizationKeys {
         public static let currentLanguage = "settings.current.language"
     }
 
+    public enum Onboarding {
+        public static let title = "onboarding.title"
+        public static let description = "onboarding.description"
+        public static let howToTitle = "onboarding.howto.title"
+        public static let howToConsume = "onboarding.howto.consume"
+        public static let howToRestore = "onboarding.howto.restore"
+        public static let howToReset = "onboarding.howto.reset"
+        public static let startButton = "onboarding.start.button"
+    }
+
     public enum Recommendation {
         public static let excellent = "recommendation.excellent"
         public static let good = "recommendation.good"

--- a/WillMeter/Presentation/Views/OnboardingView.swift
+++ b/WillMeter/Presentation/Views/OnboardingView.swift
@@ -1,0 +1,96 @@
+//
+// OnboardingView.swift
+// WillMeter
+//
+// Created by WillMeter Project
+// Licensed under CC BY-NC 4.0
+// https://creativecommons.org/licenses/by-nc/4.0/
+//
+
+import SwiftUI
+
+/// 初回起動時にアプリの目的・基本操作を説明するオンボーディング画面
+struct OnboardingView: View {
+    @EnvironmentObject var localizationService: SwiftUILocalizationService
+    let onStart: () -> Void
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Spacer()
+
+            Image(systemName: "gauge.with.dots.needle.67percent")
+                .font(.system(size: 64))
+                .foregroundStyle(.blue)
+
+            VStack(spacing: 12) {
+                Text(localizationService.localizedString(for: LocalizationKeys.Onboarding.title))
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .multilineTextAlignment(.center)
+
+                Text(localizationService.localizedString(for: LocalizationKeys.Onboarding.description))
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+
+            VStack(alignment: .leading, spacing: 16) {
+                Text(localizationService.localizedString(for: LocalizationKeys.Onboarding.howToTitle))
+                    .font(.headline)
+
+                OnboardingStepRow(
+                    systemImage: "minus.circle.fill",
+                    color: .blue,
+                    text: localizationService.localizedString(for: LocalizationKeys.Onboarding.howToConsume)
+                )
+                OnboardingStepRow(
+                    systemImage: "plus.circle.fill",
+                    color: .green,
+                    text: localizationService.localizedString(for: LocalizationKeys.Onboarding.howToRestore)
+                )
+                OnboardingStepRow(
+                    systemImage: "arrow.counterclockwise.circle.fill",
+                    color: .orange,
+                    text: localizationService.localizedString(for: LocalizationKeys.Onboarding.howToReset)
+                )
+            }
+            .padding(.horizontal, 32)
+
+            Spacer()
+
+            Button(action: onStart) {
+                Text(localizationService.localizedString(for: LocalizationKeys.Onboarding.startButton))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .padding(.horizontal, 32)
+            .padding(.bottom, 24)
+        }
+    }
+}
+
+/// オンボーディングの使い方説明1行分
+private struct OnboardingStepRow: View {
+    let systemImage: String
+    let color: Color
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: systemImage)
+                .foregroundStyle(color)
+                .frame(width: 24)
+
+            Text(text)
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+#Preview {
+    OnboardingView {}
+        .environmentObject(SwiftUILocalizationService())
+}

--- a/WillMeter/Resources/en.lproj/Localizable.strings
+++ b/WillMeter/Resources/en.lproj/Localizable.strings
@@ -44,6 +44,15 @@
 "recommendation.low" = "Feeling a bit tired. Consider lighter tasks or taking a break.";
 "recommendation.critical" = "Willpower is insufficient. Please take adequate rest.";
 
+// MARK: - Onboarding
+"onboarding.title" = "Welcome to WillMeter";
+"onboarding.description" = "Visualize your willpower and stay focused on what truly matters.";
+"onboarding.howto.title" = "How to use";
+"onboarding.howto.consume" = "Tap \"Consume\" when you work on a task to reduce your willpower";
+"onboarding.howto.restore" = "Tap \"Restore\" when you take a break to regain willpower";
+"onboarding.howto.reset" = "Tap \"Reset\" anytime to return to the maximum value";
+"onboarding.start.button" = "Get Started";
+
 // MARK: - Language Settings
 "settings.language" = "Language";
 "settings.current.language" = "Current Language";

--- a/WillMeter/Resources/ja.lproj/Localizable.strings
+++ b/WillMeter/Resources/ja.lproj/Localizable.strings
@@ -44,6 +44,15 @@
 "recommendation.low" = "少し疲れています。軽めのタスクか休憩を取ることをお勧めします。";
 "recommendation.critical" = "意志力が不足しています。十分な休息を取りましょう。";
 
+// MARK: - オンボーディング
+"onboarding.title" = "WillMeterへようこそ";
+"onboarding.description" = "ウィルパワー（意思力）を可視化し、本当に大切なことに集中するためのアプリです。";
+"onboarding.howto.title" = "使い方";
+"onboarding.howto.consume" = "タスクに取り組んだら「消費」でウィルパワーを減らします";
+"onboarding.howto.restore" = "休憩したら「回復」でウィルパワーを補います";
+"onboarding.howto.reset" = "「リセット」でいつでも最大値に戻せます";
+"onboarding.start.button" = "始める";
+
 // MARK: - 言語設定
 "settings.language" = "言語";
 "settings.current.language" = "現在の言語";

--- a/WillMeter/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WillMeter/Resources/zh-Hans.lproj/Localizable.strings
@@ -44,6 +44,15 @@
 "recommendation.low" = "有些疲劳，建议处理轻松的任务或休息一下。";
 "recommendation.critical" = "意志力不足，请充分休息。";
 
+// MARK: - 引导页
+"onboarding.title" = "欢迎使用意志力计";
+"onboarding.description" = "将意志力可视化，帮助你专注于真正重要的事情。";
+"onboarding.howto.title" = "使用方法";
+"onboarding.howto.consume" = "完成任务后点击「消耗」以减少意志力";
+"onboarding.howto.restore" = "休息后点击「恢复」以补充意志力";
+"onboarding.howto.reset" = "随时点击「重置」恢复到最大值";
+"onboarding.start.button" = "开始使用";
+
 // MARK: - 语言设置
 "settings.language" = "语言";
 "settings.current.language" = "当前语言";


### PR DESCRIPTION
## 概要
実装済み画面が実質2つ（メイン画面・言語設定）のみで、初見ユーザーがアプリの目的や操作方法（消費/回復ボタンの意味など）を理解する導線が無かった。

## 変更内容
- `OnboardingView` を追加。アプリの目的説明と、消費/回復/リセットの使い方を3項目で簡潔に示す
- `ContentView` に `@AppStorage("hasCompletedOnboarding")` を持たせ、`fullScreenCover` で初回起動時のみ表示。「始める」ボタンまたはスワイプでの明示的な閉じ操作でフラグを立て、2回目以降はスキップされる
- 3言語分のローカライズ文字列を追加

## 動作確認
- `swiftlint --quiet`（警告0件） / `xcodebuild test`（全件） / `xcodebuild build` が成功
- シミュレータで初回起動時にオンボーディングが表示されることをスクリーンショットで確認
- `hasCompletedOnboarding` をtrueにした状態（2回目起動相当）でオンボーディングがスキップされ、メイン画面が直接表示されることを確認

## Closes
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)