### PR TITLE
fix: Markdown変更でもAIレビューを実行

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
     paths-ignore:
-      - '**/*.md'
       - '**/*.txt'
       - '**/*.lock'
       - '**/package-lock.json'

--- a/scripts/ai-review/lib.mjs
+++ b/scripts/ai-review/lib.mjs
@@ -8,7 +8,6 @@ export const resultPath = `${outputDir}/result.json`;
 export const commentPath = `${outputDir}/comment.md`;
 
 const excludedDiffPathspecs = [
-  ":(exclude,glob)**/*.md",
   ":(exclude,glob)**/*.txt",
   ":(exclude,glob)**/*.lock",
   ":(exclude,glob)**/package-lock.json",

--- a/scripts/ai-review/lib.test.mjs
+++ b/scripts/ai-review/lib.test.mjs
@@ -66,13 +66,13 @@ test("parseReviewJsonは高確信度の重大指摘だけを最大3件残す", (
   assert.ok(result.findings.every((finding) => finding.severity === "medium"));
 });
 
-test("buildDiffArgsは少ない文脈で自動生成物と文書を除外する", () => {
+test("buildDiffArgsは少ない文脈で自動生成物を除外しMarkdownを残す", () => {
   const args = buildDiffArgs("origin/main...HEAD");
 
   assert.ok(args.includes("--unified=20"));
   assert.ok(args.includes("--diff-filter=ACDMRT"));
   assert.ok(args.includes("origin/main...HEAD"));
-  assert.ok(args.includes(":(exclude,glob)**/*.md"));
+  assert.equal(args.includes(":(exclude,glob)**/*.md"), false);
   assert.ok(args.includes(":(exclude,glob)**/package-lock.json"));
   assert.ok(args.includes(":(exclude,glob)**/dist/**"));
   assert.ok(args.includes(":(exclude,glob)**/*.png"));


### PR DESCRIPTION
## 変更内容

- AI ReviewワークフローのMarkdown除外を解除
- AIへ渡すdiffのMarkdown除外を解除
- Markdownをレビュー対象に残すテストへ更新

## 原因

PR #59・#60はMarkdownのみの変更だったため、`paths-ignore` とGit pathspecの両方で除外され、AI Reviewが起動していませんでした。

## 検証

- `node --test scripts/ai-review/lib.test.mjs`
- AIレビュー関連JavaScriptの構文確認
- `.github/workflows/ai-review.yml` のYAML構文確認
- `git diff --check`
