### PR TITLE
fix: pre-commitで未ステージ変更を保持

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ WillMeter は意思力を「見える化」することで：
 
 本プロジェクトは **Simple First** を設計方針とします。ドメインロジックを UI・永続化から分離しつつ、レイヤーや抽象化の一律強制はしません。判断の経緯は [ADR 0002](docs/adr/0002-adopt-simple-first-architecture.md) を参照してください。
 
-```
+```text
 WillMeter/
 ├── WillMeterApp.swift        ← エントリポイント
 ├── ContentView.swift         ← メイン画面と依存の組み立て

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "1.0.0",
   "description": "意思力を見える化して、本当に大切なことに集中する iOS アプリ",
   "scripts": {
-    "clean:whitespace": "git ls-files -z '*.swift' | xargs -0 sed -i '' 's/[[:space:]]*$//' && echo '✅ 全Swiftファイルの末尾空白を除去しました'",
-    "clean:all": "npm run clean:whitespace && git ls-files -z '*.yml' '*.yaml' '*.md' | xargs -0 sed -i '' 's/[[:space:]]*$//' && echo '✅ 全ファイルの末尾空白を除去しました'",
+    "clean:whitespace": "bash scripts/clean-trailing-whitespace.sh swift && echo '✅ 全Swiftファイルの末尾空白を除去しました'",
+    "clean:all": "bash scripts/clean-trailing-whitespace.sh all && echo '✅ 全ファイルの末尾空白を除去しました'",
     "lint": "swiftlint",
     "lint:fix": "swiftlint --fix",
     "quality:check": "npm run clean:all && npm run lint",
-    "pre-commit": "npm run quality:check"
+    "pre-commit": "npm run quality:check",
+    "test:scripts": "bash scripts/tests/pre-commit-test.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/clean-trailing-whitespace.sh
+++ b/scripts/clean-trailing-whitespace.sh
@@ -17,7 +17,7 @@ case "$scope" in
         ;;
 esac
 
-git ls-files -z --cached -- "${patterns[@]}" |
+git ls-files -z -- "${patterns[@]}" |
 while IFS= read -r -d '' file; do
     # git ls-filesは未ステージで削除されたパスも返すため、実在する通常ファイルだけを整形する。
     if [[ -f "$file" ]]; then

--- a/scripts/clean-trailing-whitespace.sh
+++ b/scripts/clean-trailing-whitespace.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+scope=${1:-all}
+
+case "$scope" in
+    swift)
+        patterns=('*.swift')
+        ;;
+    all)
+        patterns=('*.swift' '*.yml' '*.yaml' '*.md')
+        ;;
+    *)
+        echo "Usage: $0 [swift|all]" >&2
+        exit 1
+        ;;
+esac
+
+git ls-files -z --cached -- "${patterns[@]}" |
+while IFS= read -r -d '' file; do
+    # git ls-filesは未ステージで削除されたパスも返すため、実在する通常ファイルだけを整形する。
+    if [[ -f "$file" ]]; then
+        sed -i '' 's/[[:space:]]*$//' "$file"
+    fi
+done

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -6,16 +6,31 @@
 
 echo "🔍 WillMeter pre-commit hook: trailing whitespace自動除去開始..."
 
-# 1. 全Swiftファイルの末尾空白を自動除去
-# exFATドライブ上ではメタデータファイル(._* や .!*)が大量に生成され、
-# findでの全走査はsedのクラッシュとタイムアウトを招くため、
-# git追跡ファイルのみを対象にする
-echo "   📝 全Swiftファイルの末尾空白除去中..."
-git ls-files -z '*.swift' | xargs -0 sed -i '' 's/[[:space:]]*$//'
+format_staged_files() {
+    local temporary_file
+    temporary_file=$(mktemp)
+    trap 'rm -f "$temporary_file"' RETURN
 
-# 2. .swiftlint.yml, .md ファイルの末尾空白も除去
-echo "   📝 設定ファイル・ドキュメントの末尾空白除去中..."
-git ls-files -z '*.yml' '*.yaml' '*.md' | xargs -0 sed -i '' 's/[[:space:]]*$//'
+    while IFS= read -r -d '' file; do
+        git show ":$file" > "$temporary_file"
+        sed -i '' 's/[[:space:]]*$//' "$temporary_file"
+
+        if ! git show ":$file" | cmp -s - "$temporary_file"; then
+            local index_entry mode blob
+            index_entry=$(git ls-files -s -- "$file")
+            mode=${index_entry%% *}
+            blob=$(git hash-object -w "$temporary_file")
+            git update-index --cacheinfo "$mode,$blob,$file"
+        fi
+    done < <(git diff --cached --name-only --diff-filter=ACMR -z -- "$@")
+}
+
+# 作業ツリーには未ステージの変更があり得るため、ステージ済みblobだけを整形する。
+echo "   📝 ステージ済みSwiftファイルの末尾空白除去中..."
+format_staged_files '*.swift'
+
+echo "   📝 ステージ済み設定ファイル・ドキュメントの末尾空白除去中..."
+format_staged_files '*.yml' '*.yaml' '*.md'
 
 # 3. SwiftLint実行
 echo "   🔧 SwiftLint品質チェック実行中..."
@@ -29,11 +44,6 @@ if command -v swiftlint >/dev/null 2>&1; then
 else
     echo "   ⚠️  SwiftLintがインストールされていません"
 fi
-
-# 4. hookが修正したステージ済みファイルのみ再ステージする
-# (git add -A だと未追跡のメタデータや無関係な変更まで巻き込むため、ステージ済みに限定)
-echo "   📦 ステージ済みファイルを再ステージ中..."
-git diff --cached --name-only -z | xargs -0 git add -- 2>/dev/null || true
 
 echo "✅ pre-commit hook完了: trailing whitespace除去・SwiftLint実行完了"
 exit 0

--- a/scripts/tests/pre-commit-test.sh
+++ b/scripts/tests/pre-commit-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPOSITORY_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+fail() {
+    echo "❌ $1"
+    exit 1
+}
+
+test_partial_staging_is_preserved() {
+    local test_repository
+    test_repository=$(mktemp -d)
+    trap 'rm -rf "$test_repository"' RETURN
+
+    git -C "$test_repository" init --quiet
+    git -C "$test_repository" config user.email "test@example.com"
+    git -C "$test_repository" config user.name "Test User"
+    printf 'let value = 1\n' > "$test_repository/Sample.swift"
+    git -C "$test_repository" add Sample.swift
+    git -C "$test_repository" commit --quiet -m initial
+
+    printf 'let value = 2   \n' > "$test_repository/Sample.swift"
+    git -C "$test_repository" add Sample.swift
+    printf 'let value = 2   \nlet unstaged = true\n' > "$test_repository/Sample.swift"
+
+    (
+        cd "$test_repository"
+        PATH="/usr/bin:/bin" bash "$REPOSITORY_ROOT/scripts/pre-commit"
+    )
+
+    local staged_content
+    staged_content=$(git -C "$test_repository" show :Sample.swift)
+    [[ "$staged_content" == 'let value = 2' ]] || fail "ステージ済み内容だけが整形されていません"
+
+    local working_content
+    working_content=$(cat "$test_repository/Sample.swift")
+    [[ "$working_content" == $'let value = 2   \nlet unstaged = true' ]] || fail "未ステージの作業ツリーが変更されました"
+}
+
+test_deleted_tracked_file_is_ignored() {
+    local test_repository
+    test_repository=$(mktemp -d)
+    trap 'rm -rf "$test_repository"' RETURN
+
+    git -C "$test_repository" init --quiet
+    git -C "$test_repository" config user.email "test@example.com"
+    git -C "$test_repository" config user.name "Test User"
+    printf 'let deleted = true\n' > "$test_repository/Deleted.swift"
+    printf 'let existing = true   \n' > "$test_repository/Existing.swift"
+    git -C "$test_repository" add Deleted.swift Existing.swift
+    git -C "$test_repository" commit --quiet -m initial
+    rm "$test_repository/Deleted.swift"
+
+    (
+        cd "$test_repository"
+        bash "$REPOSITORY_ROOT/scripts/clean-trailing-whitespace.sh" swift
+    )
+
+    [[ $(cat "$test_repository/Existing.swift") == 'let existing = true' ]] || fail "実在するSwiftファイルが整形されていません"
+}
+
+test_partial_staging_is_preserved
+test_deleted_tracked_file_is_ignored
+
+echo "✅ pre-commitスクリプトテスト成功"

--- a/scripts/tests/pre-commit-test.sh
+++ b/scripts/tests/pre-commit-test.sh
@@ -39,7 +39,7 @@ test_partial_staging_is_preserved() {
     [[ "$working_content" == $'let value = 2   \nlet unstaged = true' ]] || fail "未ステージの作業ツリーが変更されました"
 }
 
-test_deleted_tracked_file_is_ignored() {
+test_all_tracked_files_are_cleaned_and_deleted_file_is_ignored() {
     local test_repository
     test_repository=$(mktemp -d)
     trap 'rm -rf "$test_repository"' RETURN
@@ -52,16 +52,17 @@ test_deleted_tracked_file_is_ignored() {
     git -C "$test_repository" add Deleted.swift Existing.swift
     git -C "$test_repository" commit --quiet -m initial
     rm "$test_repository/Deleted.swift"
+    printf 'let unstaged = true   \n' > "$test_repository/Existing.swift"
 
     (
         cd "$test_repository"
         bash "$REPOSITORY_ROOT/scripts/clean-trailing-whitespace.sh" swift
     )
 
-    [[ $(cat "$test_repository/Existing.swift") == 'let existing = true' ]] || fail "実在するSwiftファイルが整形されていません"
+    [[ $(cat "$test_repository/Existing.swift") == 'let unstaged = true' ]] || fail "未ステージ変更のある追跡Swiftファイルが整形されていません"
 }
 
 test_partial_staging_is_preserved
-test_deleted_tracked_file_is_ignored
+test_all_tracked_files_are_cleaned_and_deleted_file_is_ignored
 
 echo "✅ pre-commitスクリプトテスト成功"


### PR DESCRIPTION
## 概要

PR #63 のCodeRabbitレビューで指摘されたpre-commit処理のデータ整合性問題を修正します。

## 変更内容

- pre-commitの末尾空白除去を作業ツリーではなくステージ済みblobに対して実行
- 部分ステージ中の未ステージ変更を保持し、意図しないコミット混入を防止
- 未ステージで削除された追跡ファイルを末尾空白除去の対象から除外
- シェルスクリプトの回帰テストを追加
- READMEのコードフェンスへ言語指定を追加

## 原因

従来のフックは追跡ファイルの作業ツリー全体を整形した後、対象ファイル全体を `git add` していました。そのため、部分ステージされたファイルの未ステージ変更までコミットへ混入する可能性がありました。また、`git ls-files` が返す削除済みパスを `sed` に渡すとクリーンアップ処理が失敗していました。

## 検証

- `bash -n scripts/pre-commit scripts/clean-trailing-whitespace.sh scripts/tests/pre-commit-test.sh`
- `npm run test:scripts`
- `git diff --check`
- `swiftlint --quiet`
- Unit Test（`WillMeterTests`）
- iPhone 16 Simulator向けBuild

Fixes follow-up findings from #63.
