### PR TITLE
test: 永続化データ破損時の回復を保証

### DIFF
--- a/WillMeter/Infrastructure/Repositories/UserDefaultsWillPowerRepository.swift
+++ b/WillMeter/Infrastructure/Repositories/UserDefaultsWillPowerRepository.swift
@@ -26,14 +26,13 @@ public class UserDefaultsWillPowerRepository: WillPowerRepository {
     }
 
     public func load() async throws -> WillPower {
-        let maxValue = userDefaults.integer(forKey: maxValueKey)
-
-        // 初回起動時（未保存）は共通デフォルトを使用
-        guard maxValue > 0 else {
+        // 初回起動時や保存途中の不完全なデータは共通デフォルトを使用
+        guard let maxValue = userDefaults.object(forKey: maxValueKey) as? Int,
+              let currentValue = userDefaults.object(forKey: currentValueKey) as? Int,
+              maxValue > 0 else {
             return WillPower.makeDefault()
         }
 
-        let currentValue = userDefaults.integer(forKey: currentValueKey)
         return WillPower(currentValue: currentValue, maxValue: maxValue)
     }
 }

--- a/WillMeter/Infrastructure/Repositories/UserDefaultsWillPowerRepository.swift
+++ b/WillMeter/Infrastructure/Repositories/UserDefaultsWillPowerRepository.swift
@@ -26,7 +26,8 @@ public class UserDefaultsWillPowerRepository: WillPowerRepository {
     }
 
     public func load() async throws -> WillPower {
-        // 初回起動時や保存途中の不完全なデータは共通デフォルトを使用
+        // save()は現在値と最大値を必ず対で保存するため、片方の欠損や型不一致は
+        // 既存の保存形式ではなく破損データとして扱い、安全なデフォルトへ戻す
         guard let maxValue = userDefaults.object(forKey: maxValueKey) as? Int,
               let currentValue = userDefaults.object(forKey: currentValueKey) as? Int,
               maxValue > 0 else {

--- a/WillMeterTests/Infrastructure/Repositories/UserDefaultsWillPowerRepositoryTests.swift
+++ b/WillMeterTests/Infrastructure/Repositories/UserDefaultsWillPowerRepositoryTests.swift
@@ -11,6 +11,8 @@
 import XCTest
 
 final class UserDefaultsWillPowerRepositoryTests: XCTestCase {
+    private let currentValueKey = "willPower.currentValue"
+    private let maxValueKey = "willPower.maxValue"
     private var userDefaults: UserDefaults!
     private var suiteName: String!
 
@@ -49,8 +51,7 @@ final class UserDefaultsWillPowerRepositoryTests: XCTestCase {
         let loaded = try await repository.load()
 
         // Then
-        XCTAssertEqual(loaded.currentValue, WillPower.defaultCurrentValue)
-        XCTAssertEqual(loaded.maxValue, WillPower.defaultMaxValue)
+        assertDefaultWillPower(loaded)
     }
 
     func testSaveOverwritesPreviousValue() async throws {
@@ -78,5 +79,80 @@ final class UserDefaultsWillPowerRepositoryTests: XCTestCase {
         // Then
         XCTAssertEqual(loaded.currentValue, 55)
         XCTAssertEqual(loaded.maxValue, 100)
+    }
+
+    func testLoadWithOnlyMaxValueReturnsDefault() async throws {
+        // Given: 保存途中の中断などで最大値だけが残った破損状態
+        userDefaults.set(100, forKey: maxValueKey)
+        let repository = UserDefaultsWillPowerRepository(userDefaults: userDefaults)
+
+        // When
+        let loaded = try await repository.load()
+
+        // Then: 欠損した現在値を0と誤認せず、安全なデフォルトへ戻す
+        assertDefaultWillPower(loaded)
+    }
+
+    func testLoadClampsNegativeCurrentValueToZero() async throws {
+        // Given: 永続化データの現在値がドメイン下限を下回っている
+        userDefaults.set(-1, forKey: currentValueKey)
+        userDefaults.set(100, forKey: maxValueKey)
+        let repository = UserDefaultsWillPowerRepository(userDefaults: userDefaults)
+
+        // When
+        let loaded = try await repository.load()
+
+        // Then: WillPowerの不変条件に従い下限へ補正する
+        XCTAssertEqual(loaded.currentValue, 0)
+        XCTAssertEqual(loaded.maxValue, 100)
+    }
+
+    func testLoadClampsCurrentValueAboveMaximum() async throws {
+        // Given: 永続化データの現在値が最大値を超えている
+        userDefaults.set(101, forKey: currentValueKey)
+        userDefaults.set(100, forKey: maxValueKey)
+        let repository = UserDefaultsWillPowerRepository(userDefaults: userDefaults)
+
+        // When
+        let loaded = try await repository.load()
+
+        // Then: WillPowerの不変条件に従い上限へ補正する
+        XCTAssertEqual(loaded.currentValue, 100)
+        XCTAssertEqual(loaded.maxValue, 100)
+    }
+
+    func testLoadWithNonIntegerCurrentValueReturnsDefault() async throws {
+        // Given: 現在値キーに互換性のない型が保存されている
+        userDefaults.set("invalid", forKey: currentValueKey)
+        userDefaults.set(100, forKey: maxValueKey)
+        let repository = UserDefaultsWillPowerRepository(userDefaults: userDefaults)
+
+        // When
+        let loaded = try await repository.load()
+
+        // Then: 変換結果の0を有効値と誤認せず、デフォルトへ回復する
+        assertDefaultWillPower(loaded)
+    }
+
+    func testLoadWithNonIntegerMaxValueReturnsDefault() async throws {
+        // Given: 最大値キーに互換性のない型が保存されている
+        userDefaults.set(50, forKey: currentValueKey)
+        userDefaults.set("100", forKey: maxValueKey)
+        let repository = UserDefaultsWillPowerRepository(userDefaults: userDefaults)
+
+        // When
+        let loaded = try await repository.load()
+
+        // Then: 文字列を有効な最大値と解釈せず、デフォルトへ回復する
+        assertDefaultWillPower(loaded)
+    }
+
+    private func assertDefaultWillPower(
+        _ willPower: WillPower,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(willPower.currentValue, WillPower.defaultCurrentValue, file: file, line: line)
+        XCTAssertEqual(willPower.maxValue, WillPower.defaultMaxValue, file: file, line: line)
     }
 }


### PR DESCRIPTION
## 概要

Issue #38 の永続化層テストを拡充し、UserDefaultsの部分欠損・型不一致データから安全に回復できるようにします。

## 変更内容

- 最大値だけが残った部分欠損データをデフォルト値へ回復
- 現在値・最大値が整数以外の場合にデフォルト値へ回復
- 現在値が負数または最大値超過の場合、WillPowerの不変条件に従って範囲内へ補正されることをテスト
- 廃止済みOSCompatibilityLayer専用のMigrationTestsは復元対象外であることを確認

## 背景・原因

従来の `integer(forKey:)` はキー欠損や文字列型の値を0へ変換するため、破損データを有効な「意思力0」と誤認する可能性がありました。UserDefaultsの値を整数として型確認してからWillPowerを復元することで、不完全なデータを安全なデフォルトへ戻します。

## 影響

永続化キー `willPower.currentValue` / `willPower.maxValue` は変更しないため、既存の正常データとの互換性を維持します。

## 検証

- [x] TDD Red: 部分欠損・型不一致ケースが修正前に失敗
- [x] Repositoryテスト 9件が成功
- [x] 全Unit Test成功
- [x] SwiftLint成功（既存の設定警告のみ）
- [x] iPhone 16 Simulator向けBuild成功
- [x] Simulatorで文字列型の破損値を設定し、起動後に100/100へ回復することを画面確認

Closes #38